### PR TITLE
Added missing client secret parameter; added customer headers to allow cross origin

### DIFF
--- a/Skype/Trusted-Application-API/samples/AnonMeetingJoinSamples/WebRole1/Web.config
+++ b/Skype/Trusted-Application-API/samples/AnonMeetingJoinSamples/WebRole1/Web.config
@@ -31,6 +31,7 @@
     <add key="Microsoft.ServiceBus.ConnectionString" value="Endpoint=..." />
     <add key="AppTokenCertThumbprint" value="ABCDEF1234567890ABCDEF1234567890ABCDEF12" />
     <add key="AAD_ClientId" value="GUID" />
+    <add key="AAD_ClientSecret" value="GUID" />
     <add key="ApplicationEndpointId" value="sip:trustedEndpoint@tenantname.onmicrosoft.com" />
     <add key="AudienceUri" value="https://base.url" />
     <add key="CallbackUriFormat" value="https://base.url/callback?callbackContext={0}" />
@@ -52,6 +53,14 @@
     <httpRuntime targetFramework="4.5.2" />
   </system.web>
   <system.webServer>
+    <httpProtocol>
+      <customHeaders>
+        <add name="Access-Control-Allow-Origin" value="*" />
+        <add name="Access-Control-Allow-Methods" value="POST, PUT, DELETE, GET, OPTIONS" />
+        <add name="Access-Control-Allow-Headers" value="content-Type, accept, origin, X-Requested-With, Authorization, name" />
+        <add name="Access-Control-Allow-Credentials" value="true" />
+      </customHeaders>
+    </httpProtocol>
     <modules>
       <remove name="FormsAuthentication" />
     </modules>


### PR DESCRIPTION
1) The web API calls/cloud service call was failing if thumbprint is not provided in web config. Whereas code ( AzureBaseApplications -> InitializeApplicationEndpointAsync()) is written to accept client id and client secret if thumbprint is missing. However web config did not have 'Client_Secret' parameter. It is added and checked in.

2) to allow the cross origin calls the custom headers are added to config file.