### PR TITLE
PlatformSDK: Deprecate all methods which take CallbackUrl as input and provide new ones with CallbackContext as inputs

### DIFF
--- a/Skype/Trusted-Application-API/SDK/ClientModel/Capabilities/Capabilities.cs
+++ b/Skype/Trusted-Application-API/SDK/ClientModel/Capabilities/Capabilities.cs
@@ -98,8 +98,10 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
 
     public enum MessagingInvitationCapability
     {
+        [Obsolete("Use StartMeeting instead")]
         StartAdhocMeeting = 0,
-        AcceptAndBridge = 1
+        AcceptAndBridge = 1,
+        StartMeeting = 2
     }
 
     public enum AudioVideoInvitationCapability
@@ -107,8 +109,10 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
         Accept = 0,
         Forward = 1,
         Decline = 2,
+        [Obsolete("Use StartMeeting instead")]
         StartAdhocMeeting = 3,
-        AcceptAndBridge = 4
+        AcceptAndBridge = 4,
+        StartMeeting = 5
     }
 
     public enum OnlineMeetingInvitationCapability

--- a/Skype/Trusted-Application-API/SDK/ClientModel/Interfaces/Resources.cs
+++ b/Skype/Trusted-Application-API/SDK/ClientModel/Interfaces/Resources.cs
@@ -296,7 +296,10 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
 
         Task AcceptAndBridgeAsync(LoggingContext loggingContext, string meetingUri, string to);
 
+        [Obsolete("Please use StartMeetingAsync instead")]
         Task<IOnlineMeetingInvitation> StartAdhocMeetingAsync(string subject, string callbackContext, LoggingContext loggingContext = null);
+
+        Task<IOnlineMeetingInvitation> StartMeetingAsync(string subject, string callbackContext, LoggingContext loggingContext = null);
     }
 
     #endregion
@@ -352,13 +355,23 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
 
     public interface ICommunication : IPlatformResource<CommunicationCapability>
     {
+        [Obsolete("Please use the other StartMessagingAsync")]
         Task<IMessagingInvitation> StartMessagingAsync(string subject, string to, string callbackUrl, LoggingContext loggingContext = null);
 
+        Task<IMessagingInvitation> StartMessagingAsync(string subject, SipUri to, string callbackContext, LoggingContext loggingContext = null);
+
+        [Obsolete("This feature is not supported by SfB server for public applications")]
         Task<IMessagingInvitation> StartMessagingWithIdentityAsync(string subject, string to, string callbackUrl, string localUserDisplayName, string localUserUri, LoggingContext loggingContext = null);
 
+        [Obsolete("Please use the other StartAudioVideoAsync")]
         Task<IAudioVideoInvitation> StartAudioVideoAsync(string subject, string to, string callbackUrl, LoggingContext loggingContext = null);
 
+        Task<IAudioVideoInvitation> StartAudioVideoAsync(string subject, SipUri to, string callbackContext, LoggingContext loggingContext = null);
+
+        [Obsolete("Please use the other StartAudioAsync")]
         Task<IAudioVideoInvitation> StartAudioAsync(string subject, string to, string callbackUrl, LoggingContext loggingContext = null);
+
+        Task<IAudioVideoInvitation> StartAudioAsync(string subject, SipUri to, string callbackContext, LoggingContext loggingContext = null);
     }
 
     #endregion
@@ -486,7 +499,10 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
 
     public interface IMessagingInvitation : IInvitation, IPlatformResource<MessagingInvitationCapability>
     {
+        [Obsolete("Please use StartMeetingAsync")]
         Task<IOnlineMeetingInvitation> StartAdhocMeetingAsync(string subject, string callbackUrl, LoggingContext loggingContext = null);
+
+        Task<IOnlineMeetingInvitation> StartMeetingAsync(string subject, string callbackContext, LoggingContext loggingContext = null);
 
         Task AcceptAndBridgeAsync(LoggingContext loggingContext, string meetingUrl, string displayName);
     }

--- a/Skype/Trusted-Application-API/SDK/ClientModel/Resources/AdhocMeeting.cs
+++ b/Skype/Trusted-Application-API/SDK/ClientModel/Resources/AdhocMeeting.cs
@@ -62,16 +62,8 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
                 throw new CapabilityNotAvailableException("Link to join adhoc meeting is not available.");
             }
 
-            var callbackUrl = (Parent as Application).GetCustomizedCallbackUrl();
-            if (callbackUrl != null && callbackContext != null)
-            {
-                // We need to append callbackContext as a query paramter to callbackUrl
-                callbackUrl += callbackUrl.Contains("?") ? "&" : "?";
-                callbackUrl += "callbackContext=" + callbackContext;
-
-                // We don't want to pass callbackContext if callbackUrl is being passed
-                callbackContext = null;
-            }
+            string callbackUrl = null;
+            (Parent as Application).GetCallbackUrlAndCallbackContext(ref callbackUrl, ref callbackContext);
 
             var joinMeetingInput = new JoinMeetingInvitationInput()
             {

--- a/Skype/Trusted-Application-API/SDK/ClientModel/Resources/Application.cs
+++ b/Skype/Trusted-Application-API/SDK/ClientModel/Resources/Application.cs
@@ -266,6 +266,43 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
             return clientPlatform.CustomizedCallbackUrl;
         }
 
+        /// <summary>
+        /// Calculates what callbackUrl and callbackContext should be passed to PlatformService.
+        /// </summary>
+        /// <param name="callbackUrl">CallbackUrl as specified by SDK consumer as method input/parameter</param>
+        /// <param name="callbackContext">CallbackContext as specified by SDK consumer as method input/parameter</param>
+        /// <remarks>
+        /// We have some obsolete methods which expose callbackUrl to the application consuming the SDK.
+        /// These methods will be removed when we release 1.0.0 version of the SDK.
+        /// Application can also provide callbackUrl as part of the ClientPlatformSettings, which is the preferred way.
+        /// Logic explained:
+        ///  1. If the application provides callbackUrl as parameter to a method, use it as it is and do not pass callbackContext.
+        ///  2. If the application doesn't provide callbackUrl as parameter, then
+        ///    a. If callbackUrl is set in ClientPlatformSettings and callbackContext is specified, append callbackContext as a
+        ///       query parameter to callbackUrl and do not pass callbackContext
+        ///    b. If callbackUrl is set in ClientPlatformSettings and callbackContext is not specified, use callbackUrl as it is
+        ///       and do not pass callbackContext
+        ///    c. If callbackUrl is not set in ClientPlatformSettings, then pass callbackContext
+        /// </remarks>
+        internal void GetCallbackUrlAndCallbackContext(ref string callbackUrl, ref string callbackContext)
+        {
+            if (callbackUrl == null)
+            {
+                callbackUrl = GetCustomizedCallbackUrl();
+                if (callbackUrl != null && callbackContext != null)
+                {
+                    callbackUrl += callbackUrl.Contains("?") ? "&" : "?";
+                    callbackUrl += "callbackContext=" + callbackContext;
+
+                    callbackContext = null;
+                }
+            }
+            else
+            {
+                callbackContext = null;
+            }
+        }
+
         #endregion
 
         #region Private methods

--- a/Skype/Trusted-Application-API/SDK/ClientModel/Resources/Communication.cs
+++ b/Skype/Trusted-Application-API/SDK/ClientModel/Resources/Communication.cs
@@ -59,6 +59,7 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
         /// <param name="to"></param>
         /// <param name="callbackUrl"></param>
         /// <returns></returns>
+        [Obsolete("Please use the other StartMessagingAsync")]
         public Task<IMessagingInvitation> StartMessagingAsync(string subject, string to, string callbackUrl, LoggingContext loggingContext = null)
         {
             Logger.Instance.Information(string.Format("[Communication] calling startMessaging. LoggingContext: {0}",
@@ -71,7 +72,29 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
                 throw new CapabilityNotAvailableException("Link to start messaging is not available.");
             }
 
-            return StartMessagingWithIdentityAsync(subject, to, callbackUrl, href, null, null, loggingContext);
+            return StartMessagingWithIdentityAsync(subject, to, null, callbackUrl, href, null, null, loggingContext);
+        }
+
+        /// <summary>
+        /// Start messaging
+        /// </summary>
+        /// <param name="subject"></param>
+        /// <param name="to"></param>
+        /// <param name="callbackUrl"></param>
+        /// <returns></returns>
+        public Task<IMessagingInvitation> StartMessagingAsync(string subject, SipUri to, string callbackContext, LoggingContext loggingContext = null)
+        {
+            Logger.Instance.Information(string.Format("[Communication] calling startMessaging. LoggingContext: {0}",
+                 loggingContext == null ? string.Empty : loggingContext.ToString()));
+
+            string href = PlatformResource?.StartMessagingLink?.Href;
+
+            if (string.IsNullOrWhiteSpace(href))
+            {
+                throw new CapabilityNotAvailableException("Link to start messaging is not available.");
+            }
+
+            return StartMessagingWithIdentityAsync(subject, to.ToString(), callbackContext, null, href, null, null, loggingContext);
         }
 
         /// <summary>
@@ -83,6 +106,7 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
         /// <param name="localUserDisplayName"></param>
         /// <param name="localUserUri"></param>
         /// <returns></returns>
+        [Obsolete("This feature is not supported by SfB server for public applications")]
         public Task<IMessagingInvitation> StartMessagingWithIdentityAsync(string subject, string to, string callbackUrl, string localUserDisplayName, string localUserUri, LoggingContext loggingContext = null)
         {
             Logger.Instance.Information(string.Format("[Communication] calling startMessagingWithIdentity. LoggingContext: {0}",
@@ -95,7 +119,7 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
                 throw new CapabilityNotAvailableException("Link to start messaging with identity is not available.");
             }
 
-            return StartMessagingWithIdentityAsync(subject, to, callbackUrl, href, localUserDisplayName, localUserUri, loggingContext);
+            return StartMessagingWithIdentityAsync(subject, to, null, callbackUrl, href, localUserDisplayName, localUserUri, loggingContext);
         }
 
         /// <summary>
@@ -105,6 +129,7 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
         /// <param name="to"></param>
         /// <param name="callbackUrl"></param>
         /// <returns></returns>
+        [Obsolete("Please use the other StartAudioVideoAsync")]
         public Task<IAudioVideoInvitation> StartAudioVideoAsync(string subject, string to, string callbackUrl, LoggingContext loggingContext = null)
         {
             Logger.Instance.Information(string.Format("[Communication] calling startAudioVideo. LoggingContext: {0}",
@@ -117,7 +142,7 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
                 throw new CapabilityNotAvailableException("Link to start AudioVideoCall is not available.");
             }
 
-            return StartAudioVideoAsync(href, subject, to, callbackUrl, loggingContext);
+            return StartAudioVideoAsync(href, subject, to, null, callbackUrl, loggingContext);
         }
 
         /// <summary>
@@ -127,6 +152,29 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
         /// <param name="to"></param>
         /// <param name="callbackUrl"></param>
         /// <returns></returns>
+        public Task<IAudioVideoInvitation> StartAudioVideoAsync(string subject, SipUri to, string callbackContext, LoggingContext loggingContext = null)
+        {
+            Logger.Instance.Information(string.Format("[Communication] calling startAudioVideo. LoggingContext: {0}",
+                 loggingContext == null ? string.Empty : loggingContext.ToString()));
+
+            string href = PlatformResource?.StartAudioVideoLink?.Href;
+
+            if (string.IsNullOrWhiteSpace(href))
+            {
+                throw new CapabilityNotAvailableException("Link to start AudioVideoCall is not available.");
+            }
+
+            return StartAudioVideoAsync(href, subject, to.ToString(), callbackContext, null, loggingContext);
+        }
+
+        /// <summary>
+        /// Start audio video call
+        /// </summary>
+        /// <param name="subject"></param>
+        /// <param name="to"></param>
+        /// <param name="callbackUrl"></param>
+        /// <returns></returns>
+        [Obsolete("Please use the other StartAudioAsync")]
         public Task<IAudioVideoInvitation> StartAudioAsync(string subject, string to, string callbackUrl, LoggingContext loggingContext = null)
         {
             Logger.Instance.Information(string.Format("[Communication] calling startAudio. LoggingContext: {0}",
@@ -139,7 +187,29 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
                 throw new CapabilityNotAvailableException("Link to start audio is not available.");
             }
 
-            return StartAudioVideoAsync(href, subject, to, callbackUrl, loggingContext);
+            return StartAudioVideoAsync(href, subject, to, null, callbackUrl, loggingContext);
+        }
+
+        /// <summary>
+        /// Start audio video call
+        /// </summary>
+        /// <param name="subject"></param>
+        /// <param name="to"></param>
+        /// <param name="callbackUrl"></param>
+        /// <returns></returns>
+        public Task<IAudioVideoInvitation> StartAudioAsync(string subject, SipUri to, string callbackContext, LoggingContext loggingContext = null)
+        {
+            Logger.Instance.Information(string.Format("[Communication] calling startAudio. LoggingContext: {0}",
+                 loggingContext == null ? string.Empty : loggingContext.ToString()));
+
+            string href = PlatformResource?.StartAudioLink?.Href;
+
+            if (string.IsNullOrWhiteSpace(href))
+            {
+                throw new CapabilityNotAvailableException("Link to start audio is not available.");
+            }
+
+            return StartAudioVideoAsync(href, subject, to.ToString(), callbackContext, null, loggingContext);
         }
 
         public override bool Supports(CommunicationCapability capability)
@@ -379,8 +449,10 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
         /// <param name="localUserDisplayName"></param>
         /// <param name="localUserUri"></param>
         /// <returns></returns>
-        private async Task<IMessagingInvitation> StartMessagingWithIdentityAsync(string subject, string to, string callbackUrl, string href, string localUserDisplayName, string localUserUri, LoggingContext loggingContext = null)
+        private async Task<IMessagingInvitation> StartMessagingWithIdentityAsync(string subject, string to, string callbackContext, string callbackUrl, string href, string localUserDisplayName, string localUserUri, LoggingContext loggingContext = null)
         {
+            (Parent as Application).GetCallbackUrlAndCallbackContext(ref callbackUrl, ref callbackContext);
+
             string operationId = Guid.NewGuid().ToString();
             var tcs = new TaskCompletionSource<IInvitation>();
             HandleNewInviteOperationKickedOff(operationId, tcs);
@@ -390,6 +462,7 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
                 OperationContext = operationId,
                 To = to,
                 Subject = subject,
+                CallbackContext = callbackContext,
                 CallbackUrl = callbackUrl,
                 LocalUserDisplayName = localUserDisplayName,
                 LocalUserUri = localUserUri
@@ -423,8 +496,10 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
         /// <param name="to"></param>
         /// <param name="callbackUrl"></param>
         /// <returns></returns>
-        private async Task<IAudioVideoInvitation> StartAudioVideoAsync(string href, string subject, string to, string callbackUrl, LoggingContext loggingContext = null)
+        private async Task<IAudioVideoInvitation> StartAudioVideoAsync(string href, string subject, string to, string callbackContext, string callbackUrl, LoggingContext loggingContext = null)
         {
+            (Parent as Application).GetCallbackUrlAndCallbackContext(ref callbackUrl, ref callbackContext);
+
             var operationId = Guid.NewGuid().ToString();
             var tcs = new TaskCompletionSource<IInvitation>();
             HandleNewInviteOperationKickedOff(operationId, tcs);
@@ -434,6 +509,7 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
                 OperationContext = operationId,
                 To = to,
                 Subject = subject,
+                CallbackContext = callbackContext,
                 CallbackUrl = callbackUrl,
                 MediaHost = MediaHostType.Remote
             };

--- a/Skype/Trusted-Application-API/SDK/ClientModel/Resources/MessagingCall.cs
+++ b/Skype/Trusted-Application-API/SDK/ClientModel/Resources/MessagingCall.cs
@@ -209,7 +209,7 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
                     {
                         if (eventContext.EventEntity.Relationship == EventOperation.Completed)
                         {
-                            TaskCompletionSource<string> tcs = null;
+                            TaskCompletionSource<string> tcs;
                             m_outGoingmessageTcses.TryGetValue(UriHelper.CreateAbsoluteUri(this.BaseUri, eventContext.EventEntity.Link.Href).ToString().ToLower(), out tcs);
                             if (tcs != null)
                             {
@@ -219,7 +219,7 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
                                 }
                                 else if (eventContext.EventEntity.Status == EventStatus.Failure)
                                 {
-                                    string error = eventContext.EventEntity.Error == null ? null : eventContext.EventEntity.Error.GetErrorInformationString();
+                                    string error = eventContext.EventEntity.Error?.GetErrorInformationString();
                                     tcs.TrySetException(new RemotePlatformServiceException("Send Message failed with error" + error + eventContext.LoggingContext.ToString()));
                                 }
                                 else

--- a/Skype/Trusted-Application-API/SDK/ClientModel/Resources/MessagingInvitation.cs
+++ b/Skype/Trusted-Application-API/SDK/ClientModel/Resources/MessagingInvitation.cs
@@ -23,50 +23,15 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
 
         #region Public methods
 
-        public async Task<IOnlineMeetingInvitation> StartAdhocMeetingAsync(string subject, string callbackUrl, LoggingContext loggingContext = null)
+        [Obsolete("Please use StartMeetingAsync")]
+        public Task<IOnlineMeetingInvitation> StartAdhocMeetingAsync(string subject, string callbackUrl, LoggingContext loggingContext = null)
         {
-            string href = PlatformResource?.StartAdhocMeetingLink?.Href;
-            if (string.IsNullOrWhiteSpace(href))
-            {
-                throw new CapabilityNotAvailableException("Link start adhoc meeting in not available.");
-            }
+            return StartAdhocMeetingAsync(subject, null, callbackUrl, loggingContext);
+        }
 
-            Logger.Instance.Information(string.Format("[MessagingInvitation] calling StartAdhocMeetingAsync. LoggingContext:{0}", loggingContext == null ? string.Empty : loggingContext.ToString()));
-            Communication communication = this.Parent as Communication;
-
-            string operationId = Guid.NewGuid().ToString();
-            TaskCompletionSource<IInvitation> tcs = new TaskCompletionSource<IInvitation>();
-            //Adding current invitation to collection for tracking purpose.
-            communication.HandleNewInviteOperationKickedOff(operationId, tcs);
-
-            IInvitation invite = null;
-            StartAdhocMeetingInput input = new StartAdhocMeetingInput
-            {
-                Subject = subject,
-                CallbackUrl = callbackUrl,
-                OperationContext = operationId
-            };
-            var adhocMeetingUri = UriHelper.CreateAbsoluteUri(this.BaseUri, href);
-            await this.PostRelatedPlatformResourceAsync(adhocMeetingUri, input, new ResourceJsonMediaTypeFormatter(), loggingContext).ConfigureAwait(false);
-
-            await Task.WhenAny(Task.Delay(WaitForEvents), tcs.Task).ConfigureAwait(false);
-            if (!tcs.Task.IsCompleted && !tcs.Task.IsFaulted && !tcs.Task.IsCanceled)
-            {
-                throw new RemotePlatformServiceException("Timeout to get Onlinemeeting Invitation started event from platformservice!");
-            }
-            else
-            {
-                invite = await tcs.Task.ConfigureAwait(false);// Incase need to throw exception
-            }
-
-            //We are sure the invite sure be there now.
-            OnlineMeetingInvitation result = invite as OnlineMeetingInvitation;
-            if (result == null)
-            {
-                throw new RemotePlatformServiceException("Platformservice do not deliver a Onlinemeeting resource with operationId " + operationId);
-            }
-
-            return result;
+        public Task<IOnlineMeetingInvitation> StartMeetingAsync(string subject, string callbackContext, LoggingContext loggingContext = null)
+        {
+            return StartAdhocMeetingAsync(subject, callbackContext, null, loggingContext);
         }
 
         /// <summary>
@@ -107,7 +72,10 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
             string href = null;
             switch (capability)
             {
+                #pragma warning disable CS0618 // Type or member is obsolete
                 case MessagingInvitationCapability.StartAdhocMeeting:
+                #pragma warning restore CS0618 // Type or member is obsolete
+                case MessagingInvitationCapability.StartMeeting:
                     {
                         href = PlatformResource?.StartAdhocMeetingLink?.Href;
                         break;
@@ -120,6 +88,59 @@ namespace Microsoft.SfB.PlatformService.SDK.ClientModel
             }
 
             return !string.IsNullOrWhiteSpace(href);
+        }
+
+        #endregion
+
+        #region Private methods
+
+        private async Task<IOnlineMeetingInvitation> StartAdhocMeetingAsync(string subject, string callbackContext, string callbackUrl, LoggingContext loggingContext = null)
+        {
+            string href = PlatformResource?.StartAdhocMeetingLink?.Href;
+            if (string.IsNullOrWhiteSpace(href))
+            {
+                throw new CapabilityNotAvailableException("Link start adhoc meeting in not available.");
+            }
+
+            Logger.Instance.Information(string.Format("[MessagingInvitation] calling StartAdhocMeetingAsync. LoggingContext:{0}", loggingContext == null ? string.Empty : loggingContext.ToString()));
+            Communication communication = this.Parent as Communication;
+
+            string operationId = Guid.NewGuid().ToString();
+            TaskCompletionSource<IInvitation> tcs = new TaskCompletionSource<IInvitation>();
+            //Adding current invitation to collection for tracking purpose.
+            communication.HandleNewInviteOperationKickedOff(operationId, tcs);
+
+            (communication.Parent as Application).GetCallbackUrlAndCallbackContext(ref callbackUrl, ref callbackContext);
+
+            IInvitation invite = null;
+            StartAdhocMeetingInput input = new StartAdhocMeetingInput
+            {
+                Subject = subject,
+                CallbackContext = callbackContext,
+                CallbackUrl = callbackUrl,
+                OperationContext = operationId
+            };
+            var adhocMeetingUri = UriHelper.CreateAbsoluteUri(this.BaseUri, href);
+            await this.PostRelatedPlatformResourceAsync(adhocMeetingUri, input, new ResourceJsonMediaTypeFormatter(), loggingContext).ConfigureAwait(false);
+
+            await Task.WhenAny(Task.Delay(WaitForEvents), tcs.Task).ConfigureAwait(false);
+            if (!tcs.Task.IsCompleted && !tcs.Task.IsFaulted && !tcs.Task.IsCanceled)
+            {
+                throw new RemotePlatformServiceException("Timeout to get Onlinemeeting Invitation started event from platformservice!");
+            }
+            else
+            {
+                invite = await tcs.Task.ConfigureAwait(false);// Incase need to throw exception
+            }
+
+            //We are sure the invite sure be there now.
+            OnlineMeetingInvitation result = invite as OnlineMeetingInvitation;
+            if (result == null)
+            {
+                throw new RemotePlatformServiceException("Platformservice do not deliver a Onlinemeeting resource with operationId " + operationId);
+            }
+
+            return result;
         }
 
         #endregion

--- a/Skype/Trusted-Application-API/SDK/Tests/ClientModel/AudioVideoInvitation.cs
+++ b/Skype/Trusted-Application-API/SDK/Tests/ClientModel/AudioVideoInvitation.cs
@@ -246,6 +246,41 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         }
 
         [TestMethod]
+        public void ShouldSupportAcceptAndBridgeIfLinkAvailable()
+        {
+            // Given
+            IAudioVideoInvitation invitation = null;
+            m_applicationEndpoint.HandleIncomingAudioVideoCall += (sender, args) => invitation = args.NewInvite;
+
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.AudioVideoInvitationForward), HttpMethod.Post, HttpStatusCode.NoContent, null);
+
+            TestHelper.RaiseEventsFromFile(m_mockEventChannel, "Event_IncomingAudioCall.json");
+
+            // When
+            var supports = invitation.Supports(AudioVideoInvitationCapability.AcceptAndBridge);
+
+            // Then
+            Assert.IsTrue(supports);
+        }
+
+        public void ShouldNotSupportAcceptAndBridgeIfLinkIsNotAvailable()
+        {
+            // Given
+            IAudioVideoInvitation invitation = null;
+            m_applicationEndpoint.HandleIncomingAudioVideoCall += (sender, args) => invitation = args.NewInvite;
+
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.AudioVideoInvitationForward), HttpMethod.Post, HttpStatusCode.NoContent, null);
+
+            TestHelper.RaiseEventsFromFile(m_mockEventChannel, "Event_IncomingAudioCall_NoActionLink.json");
+
+            // When
+            var supports = invitation.Supports(AudioVideoInvitationCapability.AcceptAndBridge);
+
+            // Then
+            Assert.IsFalse(supports);
+        }
+
+        [TestMethod]
         [ExpectedException(typeof(ArgumentException))]
         public async Task AcceptAndBridgeAsyncShouldThrowIfBothMeetingUrlAndToNull()
         {
@@ -314,7 +349,71 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         }
 
         [TestMethod]
-        public async Task StartAdhocMeetingShouldMakeTheHttpRequest()
+        public void ShouldSuportStartAdhocMeetingIfLinkAvailable()
+        {
+            // Given
+            IAudioVideoInvitation invitation = null;
+            m_applicationEndpoint.HandleIncomingAudioVideoCall += (sender, args) => invitation = args.NewInvite;
+
+            TestHelper.RaiseEventsFromFile(m_mockEventChannel, "Event_IncomingAudioCall.json");
+
+            // When
+            var supports = invitation.Supports(AudioVideoInvitationCapability.StartAdhocMeeting);
+
+            // Then
+            Assert.IsTrue(supports);
+        }
+
+        [TestMethod]
+        public void ShouldNotSupportStartAdhocMeetingIfLinkNotAvailable()
+        {
+            // Given
+            IAudioVideoInvitation invitation = null;
+            m_applicationEndpoint.HandleIncomingAudioVideoCall += (sender, args) => invitation = args.NewInvite;
+
+            TestHelper.RaiseEventsFromFile(m_mockEventChannel, "Event_IncomingAudioCall_NoActionLinks.json");
+
+            // When
+            var supports = invitation.Supports(AudioVideoInvitationCapability.StartAdhocMeeting);
+
+            // Then
+            Assert.IsFalse(supports);
+        }
+
+        [TestMethod]
+        public void ShouldSuportStartMeetingIfLinkAvailable()
+        {
+            // Given
+            IAudioVideoInvitation invitation = null;
+            m_applicationEndpoint.HandleIncomingAudioVideoCall += (sender, args) => invitation = args.NewInvite;
+
+            TestHelper.RaiseEventsFromFile(m_mockEventChannel, "Event_IncomingAudioCall.json");
+
+            // When
+            var supports = invitation.Supports(AudioVideoInvitationCapability.StartMeeting);
+
+            // Then
+            Assert.IsTrue(supports);
+        }
+
+        [TestMethod]
+        public void ShouldNotSupportStartMeetingIfLinkNotAvailable()
+        {
+            // Given
+            IAudioVideoInvitation invitation = null;
+            m_applicationEndpoint.HandleIncomingAudioVideoCall += (sender, args) => invitation = args.NewInvite;
+
+            TestHelper.RaiseEventsFromFile(m_mockEventChannel, "Event_IncomingAudioCall_NoActionLinks.json");
+
+            // When
+            var supports = invitation.Supports(AudioVideoInvitationCapability.StartMeeting);
+
+            // Then
+            Assert.IsFalse(supports);
+        }
+
+        [TestMethod]
+        public async Task StartMeetingShouldMakeTheHttpRequest()
         {
             // Given
             IAudioVideoInvitation invitation = null;
@@ -326,7 +425,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
                 (sender, args) => TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.StartAdhocMeeting, HttpMethod.Post, "Event_OnlineMeetingInvitationStarted.json", m_mockEventChannel);
 
             // When
-            await invitation.StartAdhocMeetingAsync("Test subject", "myCallbackContext", m_loggingContext).ConfigureAwait(false);
+            await invitation.StartMeetingAsync("Test subject", "myCallbackContext", m_loggingContext).ConfigureAwait(false);
 
             // Then
             Assert.IsTrue(m_restfulClient.RequestsProcessed("POST " + DataUrls.StartAdhocMeeting));
@@ -334,7 +433,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
 
         [TestMethod]
         [ExpectedException(typeof(RemotePlatformServiceException))]
-        public async Task StartAdhocMeetingShouldThrowIfAdhocMeetingStartedEventNotReceived()
+        public async Task StartMeetingShouldThrowIfAdhocMeetingStartedEventNotReceived()
         {
             // Given
             IAudioVideoInvitation invitation = null;
@@ -345,14 +444,14 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
             ((AudioVideoInvitation)invitation).WaitForEvents = TimeSpan.FromMilliseconds(300);
 
             // When
-            await invitation.StartAdhocMeetingAsync("Test subject", "myCallbackContext", m_loggingContext).ConfigureAwait(false);
+            await invitation.StartMeetingAsync("Test subject", "myCallbackContext", m_loggingContext).ConfigureAwait(false);
 
             // Then
             // Exception is thrown
         }
 
         [TestMethod]
-        public async Task StartAdhocMeetingShouldReturnATaskToWaitForInvitationStartedEvent()
+        public async Task StartMeetingShouldReturnATaskToWaitForInvitationStartedEvent()
         {
             // Given
             IAudioVideoInvitation invitation = null;
@@ -369,7 +468,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
                 }
             };
 
-            Task invitationTask = invitation.StartAdhocMeetingAsync("Test subject", "https://example.com/callback", m_loggingContext);
+            Task invitationTask = invitation.StartMeetingAsync("Test subject", "https://example.com/callback", m_loggingContext);
             await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
             Assert.IsFalse(invitationTask.IsCompleted);
 
@@ -391,7 +490,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
                 (sender, args) => TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.StartAdhocMeeting, HttpMethod.Post, "Event_OnlineMeetingInvitationStarted.json", m_mockEventChannel);
 
             // When
-            await invitation.StartAdhocMeetingAsync("Test subject", "mycallbackContext", null).ConfigureAwait(false);
+            await invitation.StartMeetingAsync("Test subject", "mycallbackContext", null).ConfigureAwait(false);
 
             // Then
             // No exception is thrown

--- a/Skype/Trusted-Application-API/SDK/Tests/ClientModel/BridgedParticipants.cs
+++ b/Skype/Trusted-Application-API/SDK/Tests/ClientModel/BridgedParticipants.cs
@@ -34,7 +34,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
 
             // Start a conversation with messaging modality
             IMessagingInvitation invitation = await communication
-                .StartMessagingWithIdentityAsync("Test message", "sip:user@example.com", "https://example.com/callback", "Test user 1", "sip:user1@example.com")
+                .StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), "https://example.com/callback")
                 .ConfigureAwait(false);
 
             TestHelper.RaiseEventsFromFile(m_eventChannel, "Event_ConversationBridgeAdded.json");

--- a/Skype/Trusted-Application-API/SDK/Tests/ClientModel/Communication.cs
+++ b/Skype/Trusted-Application-API/SDK/Tests/ClientModel/Communication.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Rtc.Internal.Platform.ResourceContract;
 using Microsoft.SfB.PlatformService.SDK.ClientModel;
+using Microsoft.SfB.PlatformService.SDK.ClientModel.Internal;
 using Microsoft.SfB.PlatformService.SDK.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -18,6 +19,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         private ICommunication m_communication;
         private MockRestfulClient m_restfulClient;
         private Mock<IEventChannel> m_eventChannel;
+        private ClientPlatformSettings m_clientPlatformSettings;
 
         [TestInitialize]
         public async void TestSetup()
@@ -29,6 +31,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
 
             await data.ApplicationEndpoint.InitializeAsync(m_loggingContext).ConfigureAwait(false);
             await data.ApplicationEndpoint.InitializeApplicationAsync(m_loggingContext).ConfigureAwait(false);
+            m_clientPlatformSettings = data.ClientPlatformSettings;
 
             m_communication = data.ApplicationEndpoint.Application.Communication;
         }
@@ -37,8 +40,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         public async Task ShouldSupportStartMessagingIfLinkAvailable()
         {
             // Given
-            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessaging.json");
-            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+            // Setup
 
             // When
             bool supports = m_communication.Supports(CommunicationCapability.StartMessaging);
@@ -48,10 +50,11 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         }
 
         [TestMethod]
-        public void ShouldNotSupportStartMessagingIfLinkNotAvailable()
+        public async Task ShouldNotSupportStartMessagingIfLinkNotAvailable()
         {
             // Given
-            // Setup
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessagingWithIdentity.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
 
             // When
             bool supports = m_communication.Supports(CommunicationCapability.StartMessaging);
@@ -65,7 +68,8 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         public async Task StartMessagingShouldThrowIfLinkNotAvailable()
         {
             // Given
-            // Setup
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessagingWithIdentity.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
 
             // When
             await m_communication.StartMessagingAsync("Test message", "sip:user@example.com", "https://example.com/callback").ConfigureAwait(false);
@@ -78,9 +82,6 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         public async Task StartMessagingShouldWork()
         {
             // Given
-            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessaging.json");
-            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
-
             // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
             m_restfulClient.HandleRequestProcessed +=
                 (sender, args) => TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
@@ -95,10 +96,330 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         }
 
         [TestMethod]
-        public void ShouldSupportStartMessagingWithIdentityIfLinkAvailable()
+        public async Task StartMessagingShouldPassCallbackUrl()
         {
             // Given
-            // Setup
+            var callbackUrlPassed = false;
+            const string callbackUrl = "https://example.com/callback";
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if(operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl;
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication.StartMessagingAsync("Test message", "sip:user@example.com", callbackUrl).ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingShouldPassNullCallbackUrlIfNullGiven()
+        {
+            // Given
+            var callbackUrlPassed = false;
+            const string callbackUrl = null;
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl;
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication.StartMessagingAsync("Test message", "sip:user@example.com", callbackUrl).ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingShouldPassNullCallbackContext()
+        {
+            // Given
+            var callbackContextIsNull = false;
+            const string callbackUrl = "https://example.com/callback";
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackContextIsNull = input.CallbackContext == null;
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication.StartMessagingAsync("Test message", "sip:user@example.com", callbackUrl).ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackContextIsNull);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingShouldReturnTaskToWaitForInvitationStartedEvent()
+        {
+            string invitationOperationId = string.Empty;
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                string operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, null, null);
+                if (!string.IsNullOrEmpty(operationId))
+                {
+                    invitationOperationId = operationId;
+                }
+            };
+
+            // Given
+            Task invitationTask = m_communication.StartMessagingAsync("Test message", "sip:user@example.com", "https://example.com/callback");
+            await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+            Assert.IsFalse(invitationTask.IsCompleted);
+
+            // When
+            TestHelper.RaiseEventsFromFileWithOperationId(m_eventChannel, "Event_MessagingInvitationStarted.json", invitationOperationId);
+
+            // Then
+            Assert.IsTrue(invitationTask.IsCompleted);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(RemotePlatformServiceException))]
+        public async Task StartMessagingShouldThrowIfInvitationStartedEventNotReceived()
+        {
+            // Given
+            ((Communication)m_communication).WaitForEvents = TimeSpan.FromMilliseconds(200);
+
+            // When
+            await m_communication.StartMessagingAsync("Test message", "sip:user@example.com", "https://example.com/callback").ConfigureAwait(false);
+
+            // Then
+            // Exception is thrown
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(CapabilityNotAvailableException))]
+        public async Task StartMessagingWithCallbackContextShouldThrowIfLinkNotAvailable()
+        {
+            // Given
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessagingWithIdentity.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+
+            // When
+            await m_communication.StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), "__callbackcontext__").ConfigureAwait(false);
+
+            // Then
+            // Exception is thrown
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithCallbackContextShouldWork()
+        {
+            // Given
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed +=
+                (sender, args) => TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+
+            // When
+            IMessagingInvitation invitation = await m_communication.StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), "__callbackcontext__").ConfigureAwait(false);
+
+            // Then
+            Assert.IsNotNull(invitation);
+            Assert.IsNotNull(invitation.RelatedConversation);
+            Assert.IsTrue(m_restfulClient.RequestsProcessed("POST " + DataUrls.MessagingInvitations));
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithCallbackContextShouldPassCallbackUrlWhenSpecifiedInSettings()
+        {
+            // Given
+            const string callbackContext = null;
+            var callbackUrl = new Uri("https://example.com/callback");
+            var callbackUrlPassed = false;
+
+            m_clientPlatformSettings.SetCustomizedCallbackurl(callbackUrl);
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if(operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl.ToString();
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication.StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), callbackContext).ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithCallbackContextShouldNotPassCallbackUrlWhenNotSpecifiedInSettings()
+        {
+            // Given
+            const string callbackContext = "__callbackcontext__";
+            var callbackUrlPassed = true;
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl != null;
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication.StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), callbackContext).ConfigureAwait(false);
+
+            // Then
+            Assert.IsFalse(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithCallbackContextShouldPassCallbackContextWhenPassedInParameters()
+        {
+            // Given
+            const string callbackContext = "__callbackcontext__";
+            var callbackContextPassed = false;
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackContextPassed = input.CallbackContext == callbackContext;
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication.StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), callbackContext).ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackContextPassed);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithCallbackContextShouldNotPassCallbackContextWhenCallbackUrlSpecifiedInSettings()
+        {
+            // Given
+            const string callbackContext = "__callbackcontext__";
+            var callbackUrl = new Uri("https://example.com/callback");
+            var callbackContextPassed = true;
+
+            m_clientPlatformSettings.SetCustomizedCallbackurl(callbackUrl);
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackContextPassed = input.CallbackContext != null;
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication.StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), callbackContext).ConfigureAwait(false);
+
+            // Then
+            Assert.IsFalse(callbackContextPassed);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithCallbackContextShouldAppendCallbackContextToCallbackUrlWhenCallbackUrlSpecifiedInSettings()
+        {
+            // Given
+            const string callbackContext = "__callbackcontext__";
+            var callbackUrl = new Uri("https://example.com/callback");
+            var callbackUrlContainsCallbackContext = false;
+
+            m_clientPlatformSettings.SetCustomizedCallbackurl(callbackUrl);
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackUrlContainsCallbackContext = input.CallbackUrl.Contains(callbackContext);
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication.StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), callbackContext).ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlContainsCallbackContext);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithCallbackContextShouldReturnTaskToWaitForInvitationStartedEvent()
+        {
+            string invitationOperationId = string.Empty;
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                string operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, null, null);
+                if (!string.IsNullOrEmpty(operationId))
+                {
+                    invitationOperationId = operationId;
+                }
+            };
+
+            // Given
+            Task invitationTask = m_communication.StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), "__callbackContext__");
+            await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+            Assert.IsFalse(invitationTask.IsCompleted);
+
+            // When
+            TestHelper.RaiseEventsFromFileWithOperationId(m_eventChannel, "Event_MessagingInvitationStarted.json", invitationOperationId);
+
+            // Then
+            Assert.IsTrue(invitationTask.IsCompleted);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(RemotePlatformServiceException))]
+        public async Task StartMessagingWithCallbackContextShouldThrowIfInvitationStartedEventNotReceived()
+        {
+            // Given
+            ((Communication)m_communication).WaitForEvents = TimeSpan.FromMilliseconds(200);
+
+            // When
+            await m_communication.StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), "__callbackContext__").ConfigureAwait(false);
+
+            // Then
+            // Exception is thrown
+        }
+
+        [TestMethod]
+        public async Task ShouldSupportStartMessagingWithIdentityIfLinkAvailable()
+        {
+            // Given
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessagingWithIdentity.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
 
             // When
             bool supports = m_communication.Supports(CommunicationCapability.StartMessagingWithIdentity);
@@ -111,8 +432,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         public async Task ShouldNotSupportStartMessagingWithIdentityIfLinkNotAvailable()
         {
             // Given
-            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessaging.json");
-            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+            // Setup
 
             // When
             bool supports = m_communication.Supports(CommunicationCapability.StartMessagingWithIdentity);
@@ -126,8 +446,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         public async Task StartMessagingWithIdentityShouldThrowIfLinkNotAvailable()
         {
             // Given
-            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessaging.json");
-            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+            // Setup
 
             // When
             await m_communication.StartMessagingWithIdentityAsync("Test message", "sip:user@example.com", "https://example.com/callback", "Test user", "sip:user1@example.com").ConfigureAwait(false);
@@ -140,6 +459,8 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         public async Task StartMessagingWithIdentityShouldWork()
         {
             // Given
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessagingWithIdentity.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
             // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
             m_restfulClient.HandleRequestProcessed +=
                 (sender, args) => TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
@@ -153,6 +474,140 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
             Assert.IsNotNull(invitation);
             Assert.IsNotNull(invitation.RelatedConversation);
             Assert.IsTrue(m_restfulClient.RequestsProcessed("POST " + DataUrls.MessagingInvitations));
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithIdentityShouldPassCallbackUrl()
+        {
+            // Given
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessagingWithIdentity.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+
+            var callbackUrlPassed = false;
+            const string callbackUrl = "https://example.com/callback";
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl;
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication
+                .StartMessagingWithIdentityAsync("Test message", "sip:user@example.com", callbackUrl, "Test user 1", "sip:user1@example.com")
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithIdentityShouldPassNullCallbackUrlIfNullGiven()
+        {
+            // Given
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessagingWithIdentity.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+
+            var callbackUrlPassed = false;
+            const string callbackUrl = null;
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl;
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication
+                .StartMessagingWithIdentityAsync("Test message", "sip:user@example.com", callbackUrl, "Test user 1", "sip:user1@example.com")
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithIdentityShouldPassNullCallbackContext()
+        {
+            // Given
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessagingWithIdentity.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+
+            var callbackUrlPassed = false;
+            const string callbackUrl = "https://example.com/callback";
+
+            // If ClientModel starts a MessagingInvitation, deliver the corresponding invitation started event.
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, "Event_MessagingInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as MessagingInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl;
+                }
+            };
+
+            // When
+            IMessagingInvitation invitation = await m_communication
+                .StartMessagingWithIdentityAsync("Test message", "sip:user@example.com", callbackUrl, "Test user 1", "sip:user1@example.com")
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartMessagingWithIdentityShouldReturnTaskToWaitForInvitationStartedEvent()
+        {
+            string invitationOperationId = string.Empty;
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                string operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.MessagingInvitations, HttpMethod.Post, null, null);
+                if (!string.IsNullOrEmpty(operationId))
+                {
+                    invitationOperationId = operationId;
+                }
+            };
+
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessagingWithIdentity.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+
+            // Given
+            Task invitationTask = m_communication.StartMessagingWithIdentityAsync("Test message", "sip:user@example.com", "https://example.com/callback", "Test user 1", "sip:user1@example.com");
+            await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+            Assert.IsFalse(invitationTask.IsCompleted);
+
+            // When
+            TestHelper.RaiseEventsFromFileWithOperationId(m_eventChannel, "Event_MessagingInvitationStarted.json", invitationOperationId);
+
+            // Then
+            Assert.IsTrue(invitationTask.IsCompleted);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(RemotePlatformServiceException))]
+        public async Task StartMessagingWithIdentityShouldThrowIfInvitationStartedEventNotReceived()
+        {
+            // Given
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_WithStartMessagingWithIdentity.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+            ((Communication)m_communication).WaitForEvents = TimeSpan.FromMilliseconds(200);
+
+            // When
+            await m_communication.StartMessagingWithIdentityAsync("Test message", "sip:user@example.com", "https://example.com/callback", "Test user 1", "sip:user1@example.com").ConfigureAwait(false);
+
+            // Then
+            // Exception is thrown
         }
 
         [TestMethod]
@@ -254,6 +709,288 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
         }
 
         [TestMethod]
+        public async Task StartAudioShouldPassCallbackUrl()
+        {
+            // Given
+            const string callbackUrl = "https://example.com/callback";
+            var callbackUrlPassed = false;
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if(operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication.StartAudioAsync("Test subject", "sip:user@example.com", callbackUrl).ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioShouldPassNullCallbackUrlIfNullGiven()
+        {
+            // Given
+            const string callbackUrl = null;
+            var callbackUrlPassed = false;
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication.StartAudioAsync("Test subject", "sip:user@example.com", callbackUrl).ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioShouldPassNullCallbackContext()
+        {
+            // Given
+            const string callbackUrl = "https://example.com/callback";
+            var callbackContextPassed = true;
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackContextPassed = input.CallbackContext != null;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication.StartAudioAsync("Test subject", "sip:user@example.com", callbackUrl).ConfigureAwait(false);
+
+            // Then
+            Assert.IsFalse(callbackContextPassed);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(CapabilityNotAvailableException))]
+        public async Task StartAudioWithCallbackContextShouldThrowIfLinkNotAvailable()
+        {
+            // Given
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_NoStartAudio.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+
+            // When
+            await m_communication.StartAudioAsync("Test subject", new SipUri("sip:user@example.com"), "__callbackcontext__").ConfigureAwait(false);
+
+            // Then
+            // Exception is thrown
+        }
+
+        [TestMethod]
+        public async Task StartAudioWithCallbackContextShouldWork()
+        {
+            // Given
+            m_restfulClient.HandleRequestProcessed += (sender, args) => TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioAsync("Test subject", new SipUri("sip:user@example.com"), "__callbackcontext__")
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsNotNull(invitation);
+            Assert.IsNotNull(invitation.RelatedConversation);
+            Assert.IsTrue(m_restfulClient.RequestsProcessed("POST " + DataUrls.AudioInvitations));
+        }
+
+        [TestMethod]
+        public async Task StartAudioWithCallbackContextShouldReturnTaskToWaitForInvitationStartedEvent()
+        {
+            string invitationOperationId = string.Empty;
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                string operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioInvitations, HttpMethod.Post, null, null);
+                if (!string.IsNullOrEmpty(operationId))
+                {
+                    invitationOperationId = operationId;
+                }
+            };
+
+            // Given
+            Task invitationTask = m_communication.StartAudioAsync("Test subject", new SipUri("sip:user@example.com"), "__callbackcontext__");
+            await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+            Assert.IsFalse(invitationTask.IsCompleted);
+
+            // When
+            TestHelper.RaiseEventsFromFileWithOperationId(m_eventChannel, "Event_AudioVideoInvitationStarted.json", invitationOperationId);
+
+            // Then
+            Assert.IsTrue(invitationTask.IsCompleted);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(RemotePlatformServiceException))]
+        public async Task StartAudioWithCallbackContextShouldThrowIfInvitationStartedEventNotReceived()
+        {
+            // Given
+            ((Communication)m_communication).WaitForEvents = TimeSpan.FromMilliseconds(200);
+
+            // When
+            await m_communication.StartAudioAsync("Test subject", new SipUri("sip:user@example.com"), "__callbackcontext__").ConfigureAwait(false);
+
+            // Then
+            // Exception is thrown
+        }
+
+        [TestMethod]
+        public async Task StartAudioWithCallbackContextShouldPassCallbackUrlWhenSpecifiedInSettings()
+        {
+            // Given
+            var callbackUrl = new Uri("https://example.com/callback");
+            const string callbackContext = "__callbackcontext__";
+            var callbackUrlPassed = false;
+
+            m_clientPlatformSettings.SetCustomizedCallbackurl(callbackUrl);
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if(operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl.StartsWith(callbackUrl.ToString());
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioAsync("Test subject", new SipUri("sip:user@example.com"), callbackContext)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioWithCallbackContextShouldNotPassCallbackUrlWhenNotSpecifiedInSettings()
+        {
+            // Given
+            const string callbackContext = "__callbackcontext__";
+            var callbackUrlPassed = true;
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl != null;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioAsync("Test subject", new SipUri("sip:user@example.com"), callbackContext)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsFalse(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioWithCallbackContextShouldPassCallbackContextWhenPassedInParameters()
+        {
+            // Given
+            const string callbackContext = "__callbackcontext__";
+            var callbackContextPassed = false;
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackContextPassed = input.CallbackContext != null;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioAsync("Test subject", new SipUri("sip:user@example.com"), callbackContext)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackContextPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioWithCallbackContextShouldNotPassCallbackContextWhenCallbackUrlSpecifiedInSettings()
+        {
+            // Given
+            var callbackUrl = new Uri("https://example.com/callback");
+            const string callbackContext = "__callbackcontext__";
+            var callbackContextPassed = true;
+
+            m_clientPlatformSettings.SetCustomizedCallbackurl(callbackUrl);
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackContextPassed = input.CallbackContext != null;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioAsync("Test subject", new SipUri("sip:user@example.com"), callbackContext)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsFalse(callbackContextPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioWithCallbackContextShouldAppendCallbackContextToCallbackUrlWhenCallbackUrlSpecifiedInSettings()
+        {
+            // Given
+            var callbackUrl = new Uri("https://example.com/callback");
+            const string callbackContext = "__callbackcontext__";
+            var callbackUrlContainsCallbackContext = true;
+
+            m_clientPlatformSettings.SetCustomizedCallbackurl(callbackUrl);
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackUrlContainsCallbackContext = input.CallbackUrl.Contains(callbackContext);
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioAsync("Test subject", new SipUri("sip:user@example.com"), callbackContext)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlContainsCallbackContext);
+        }
+
+        [TestMethod]
         public void ShouldSupportStartAudioVideoIfLinkAvailable()
         {
             // Given
@@ -350,6 +1087,292 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
 
             // Then
             // Exception is thrown
+        }
+
+        [TestMethod]
+        public async Task StartAudioVideoShouldPassCallbackUrl()
+        {
+            // Given
+            const string callbackUrl = "https://example.com/callback";
+            var callbackUrlPassed = false;
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioVideoInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if(operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioVideoAsync("Test subject", "sip:user@example.com", callbackUrl)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioVideoShouldPassNullCallbackUrlIfNullGiven()
+        {
+            // Given
+            const string callbackUrl = null;
+            var callbackUrlPassed = false;
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioVideoInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioVideoAsync("Test subject", "sip:user@example.com", callbackUrl)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioVideoShouldPassNullCallbackContext()
+        {
+            // Given
+            const string callbackUrl = "https://example.com/callback";
+            var callbackContextPassed = true;
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioVideoInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackContextPassed = input.CallbackContext != null;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioVideoAsync("Test subject", "sip:user@example.com", callbackUrl)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsFalse(callbackContextPassed);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(CapabilityNotAvailableException))]
+        public async Task StartAudioVideoWithCallbackContextShouldThrowIfLinkNotAvailable()
+        {
+            // Given
+            m_restfulClient.OverrideResponse(new Uri(DataUrls.Communication), HttpMethod.Get, HttpStatusCode.OK, "Communication_NoStartAudioVideo.json");
+            await m_communication.RefreshAsync(m_loggingContext).ConfigureAwait(false);
+
+            // When
+            await m_communication.StartAudioVideoAsync("Test subject", new SipUri("sip:user@example.com"), "__callbackcontext__").ConfigureAwait(false);
+
+            // Then
+            // Exception is thrown
+        }
+
+        [TestMethod]
+        public async Task StartAudioVideoWithCallbackContextShouldWork()
+        {
+            // Given
+            m_restfulClient.HandleRequestProcessed +=
+                (sender, args) => TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioVideoInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioVideoAsync("Test subject", new SipUri("sip:user@example.com"), "__callbackcontext__")
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsNotNull(invitation);
+            Assert.IsNotNull(invitation.RelatedConversation);
+            Assert.IsTrue(m_restfulClient.RequestsProcessed("POST " + DataUrls.AudioVideoInvitations));
+        }
+
+        [TestMethod]
+        public async Task StartAudioVideoWithCallbackContextShouldReturnTaskToWaitForInvitationStartedEvent()
+        {
+            string invitationOperationId = string.Empty;
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                string operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioVideoInvitations, HttpMethod.Post, null, null);
+                if (!string.IsNullOrEmpty(operationId))
+                {
+                    invitationOperationId = operationId;
+                }
+            };
+
+            // Given
+            Task invitationTask = m_communication.StartAudioVideoAsync("Test subject", new SipUri("sip:user@example.com"), "__callbackcontext__");
+            await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+            Assert.IsFalse(invitationTask.IsCompleted);
+
+            // When
+            TestHelper.RaiseEventsFromFileWithOperationId(m_eventChannel, "Event_AudioVideoInvitationStarted.json", invitationOperationId);
+
+            // Then
+            Assert.IsTrue(invitationTask.IsCompleted);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(RemotePlatformServiceException))]
+        public async Task StartAudioVideoWithCallbackContextShouldThrowIfInvitationStartedEventNotReceived()
+        {
+            // Given
+            ((Communication)m_communication).WaitForEvents = TimeSpan.FromMilliseconds(200);
+
+            // When
+            await m_communication.StartAudioVideoAsync("Test subject", new SipUri("sip:user@example.com"), "__callbackcontext__").ConfigureAwait(false);
+
+            // Then
+            // Exception is thrown
+        }
+
+        [TestMethod]
+        public async Task StartAudioVideoWithCallbackContextShouldPassCallbackUrlWhenSpecifiedInSettings()
+        {
+            // Given
+            var callbackUrl = new Uri("https://example.com/callback");
+            const string callbackContext = null;
+            var callbackUrlPassed = false;
+
+            m_clientPlatformSettings.SetCustomizedCallbackurl(callbackUrl);
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioVideoInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if(operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl == callbackUrl.ToString();
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioVideoAsync("Test subject", new SipUri("sip:user@example.com"), callbackContext)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioVideoWithCallbackContextShouldNotPassCallbackUrlWhenNotSpecifiedInSettings()
+        {
+            // Given
+            const string callbackContext = null;
+            var callbackUrlPassed = true;
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioVideoInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackUrlPassed = input.CallbackUrl != null;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioVideoAsync("Test subject", new SipUri("sip:user@example.com"), callbackContext)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsFalse(callbackUrlPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioVideoWithCallbackContextShouldPassCallbackContextWhenPassedInParameters()
+        {
+            // Given
+            const string callbackContext = "__callbackcontext__";
+            var callbackContextPassed = false;
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioVideoInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackContextPassed = input.CallbackContext == callbackContext;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioVideoAsync("Test subject", new SipUri("sip:user@example.com"), callbackContext)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackContextPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioVideoWithCallbackContextShouldNotPassCallbackContextWhenCallbackUrlSpecifiedInSettings()
+        {
+            // Given
+            var callbackUrl = new Uri("https://example.com/callback");
+            const string callbackContext = "__callbackcontext__";
+            var callbackContextPassed = true;
+
+            m_clientPlatformSettings.SetCustomizedCallbackurl(callbackUrl);
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioVideoInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackContextPassed = input.CallbackContext != null;
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioVideoAsync("Test subject", new SipUri("sip:user@example.com"), callbackContext)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsFalse(callbackContextPassed);
+        }
+
+        [TestMethod]
+        public async Task StartAudioVideoWithCallbackContextShouldAppendCallbackContextToCallbackUrlWhenCallbackUrlSpecifiedInSettings()
+        {
+            // Given
+            var callbackUrl = new Uri("https://example.com/callback");
+            const string callbackContext = "__callbackcontext__";
+            var callbackUrlContainsCallbackContext = false;
+
+            m_clientPlatformSettings.SetCustomizedCallbackurl(callbackUrl);
+
+            m_restfulClient.HandleRequestProcessed += (sender, args) =>
+            {
+                var operationId = TestHelper.RaiseEventsOnHttpRequest(args, DataUrls.AudioVideoInvitations, HttpMethod.Post, "Event_AudioVideoInvitationStarted.json", m_eventChannel);
+                if (operationId != null)
+                {
+                    var input = args.Input as AudioVideoInvitationInput;
+                    callbackUrlContainsCallbackContext = input.CallbackUrl.Contains(callbackContext);
+                }
+            };
+
+            // When
+            IAudioVideoInvitation invitation = await m_communication
+                .StartAudioVideoAsync("Test subject", new SipUri("sip:user@example.com"), callbackContext)
+                .ConfigureAwait(false);
+
+            // Then
+            Assert.IsTrue(callbackUrlContainsCallbackContext);
         }
     }
 }

--- a/Skype/Trusted-Application-API/SDK/Tests/ClientModel/Conversation.cs
+++ b/Skype/Trusted-Application-API/SDK/Tests/ClientModel/Conversation.cs
@@ -47,7 +47,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
 
             // Start a conversation with messaging modality
             IMessagingInvitation invitation = await communication
-                .StartMessagingWithIdentityAsync("Test message", "sip:user@example.com", "https://example.com/callback", "Test user 1", "sip:user1@example.com")
+                .StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), "https://example.com/callback")
                 .ConfigureAwait(false);
 
             m_conversation = invitation.RelatedConversation;

--- a/Skype/Trusted-Application-API/SDK/Tests/ClientModel/ConversationBridge.cs
+++ b/Skype/Trusted-Application-API/SDK/Tests/ClientModel/ConversationBridge.cs
@@ -34,7 +34,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
 
             // Start a conversation with messaging modality
             IMessagingInvitation invitation = await communication
-                .StartMessagingWithIdentityAsync("Test message", "sip:user@example.com", "https://example.com/callback", "Test user 1", "sip:user1@example.com")
+                .StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), "https://example.com/callback")
                 .ConfigureAwait(false);
 
             TestHelper.RaiseEventsFromFile(m_eventChannel, "Event_ConversationBridgeAdded.json");

--- a/Skype/Trusted-Application-API/SDK/Tests/ClientModel/ConversationConference.cs
+++ b/Skype/Trusted-Application-API/SDK/Tests/ClientModel/ConversationConference.cs
@@ -34,7 +34,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
 
             // Start a conversation with messaging modality
             IMessagingInvitation invitation = await communication
-                .StartMessagingWithIdentityAsync("Test message", "sip:user@example.com", "https://example.com/callback", "Test user 1", "sip:user1@example.com")
+                .StartMessagingAsync("Test message", new SipUri("sip:user@example.com"), "https://example.com/callback")
                 .ConfigureAwait(false);
 
             TestHelper.RaiseEventsFromFile(m_eventChannel, "Event_ConversationConferenceAdded.json");

--- a/Skype/Trusted-Application-API/SDK/Tests/ClientModel/MessagingCall.cs
+++ b/Skype/Trusted-Application-API/SDK/Tests/ClientModel/MessagingCall.cs
@@ -49,12 +49,10 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
             };
 
             // Establish a messaging call
-            IMessagingInvitation invitation = await communication.StartMessagingWithIdentityAsync(
+            IMessagingInvitation invitation = await communication.StartMessagingAsync(
                 "Test subject",
-                "sip:user@example.com",
+                new SipUri("sip:user@example.com"),
                 "https://example.com/callback",
-                "Local user",
-                "sip:user1@example.com",
                 m_loggingContext).ConfigureAwait(false);
 
             TestHelper.RaiseEventsFromFile(m_mockEventChannel, "Event_ConversationConnected.json"); // It has link to the messaging call

--- a/Skype/Trusted-Application-API/SDK/Tests/ClientModel/Participant.cs
+++ b/Skype/Trusted-Application-API/SDK/Tests/ClientModel/Participant.cs
@@ -39,7 +39,7 @@ namespace Microsoft.SfB.PlatformService.SDK.Tests.ClientModel
             };
 
             IMessagingInvitation invitation = await applicationEndpoint.Application.Communication
-                .StartMessagingWithIdentityAsync("Test subject", "sip:user@example.com", "https://example.com/callback", "Local user", "sip:user1@example.com", m_loggingContext)
+                .StartMessagingAsync("Test subject", new SipUri("sip:user@example.com"), "https://example.com/callback", m_loggingContext)
                 .ConfigureAwait(false);
 
             m_conversation = invitation.RelatedConversation;

--- a/Skype/Trusted-Application-API/SDK/Tests/Data/Application.json
+++ b/Skype/Trusted-Application-API/SDK/Tests/Data/Application.json
@@ -19,7 +19,7 @@
         "ms:rtc:saas:inviteUserToMeeting": {
           "href": "/platformservice/v1/applications/1393347000/communication/userMeetingInvitations?endpointId=sip:monitoringaudio@0mcorp2cloudperf.onmicrosoft.com"
         },
-        "ms:rtc:saas:startMessagingWithIdentity": {
+        "ms:rtc:saas:startMessaging": {
           "href": "/platformservice/v1/applications/1393347000/communication/messagingInvitations?endpointId=sip:monitoringaudio@0mcorp2cloudperf.onmicrosoft.com"
         },
         "ms:rtc:saas:startAudioVideo": {

--- a/Skype/Trusted-Application-API/SDK/Tests/Data/Communication_WithStartMessagingWithIdentity.json
+++ b/Skype/Trusted-Application-API/SDK/Tests/Data/Communication_WithStartMessagingWithIdentity.json
@@ -9,7 +9,7 @@
     "ms:rtc:saas:inviteUserToMeeting": {
       "href": "/platformservice/v1/applications/1393347000/communication/userMeetingInvitations?endpointId=sip:monitoringaudio@0mcorp2cloudperf.onmicrosoft.com"
     },
-    "ms:rtc:saas:startMessaging": {
+    "ms:rtc:saas:startMessagingWithIdentity": {
       "href": "/platformservice/v1/applications/1393347000/communication/messagingInvitations?endpointId=sip:monitoringaudio@0mcorp2cloudperf.onmicrosoft.com"
     },
     "ms:rtc:saas:startAudioVideo": {

--- a/Skype/Trusted-Application-API/SDK/Tests/Data/Event_IncomingAudioCall_NoActionLinks.json
+++ b/Skype/Trusted-Application-API/SDK/Tests/Data/Event_IncomingAudioCall_NoActionLinks.json
@@ -33,9 +33,6 @@
                 "ms:rtc:saas:conversation": {
                   "href": "/platformservice/tgt-8c81281c925a5c2ea02ec14ac1b492c6/v1/applications/1393347000/communication/conversations/0d5d91ec-5eaf-402e-95a9-6f09a2787ad5?endpointId=sip:monitoringaudio@0mcorp2cloudperf.onmicrosoft.com"
                 },
-                "ms:rtc:saas:startAdhocMeeting": {
-                  "href": "/platformservice/tgt-8c81281c925a5c2ea02ec14ac1b492c6/v1/applications/1393347000/communication/onlineMeetingInvitations/startAdhocMeeting?endpointId=sip:monitoringaudio@0mcorp2cloudperf.onmicrosoft.com"
-                },
                 "ms:rtc:saas:audioVideo": {
                   "href": "/platformservice/tgt-8c81281c925a5c2ea02ec14ac1b492c6/v1/applications/1393347000/communication/conversations/0d5d91ec-5eaf-402e-95a9-6f09a2787ad5/audioVideo?endpointId=sip:monitoringaudio@0mcorp2cloudperf.onmicrosoft.com"
                 }


### PR DESCRIPTION
PlatformSDK: Deprecate all methods which take CallbackUrl as input and provide new ones with CallbackContext as inputs