### PR TITLE
Update PTVideoGroupGoogleChrome.md

### DIFF
--- a/Skype/WebSDK/docs/PTVideoGroupGoogleChrome.md
+++ b/Skype/WebSDK/docs/PTVideoGroupGoogleChrome.md
@@ -40,7 +40,7 @@ conversation.videoService.activeSpeaker.participant.changed(function (participan
 
         // add listener to turn video on/off
         channel.isVideoOn.changed(function (isVideoOn) {
-            channel.source.sink.container(/* DOM node */);
+            channel.stream.source.sink.container(/* DOM node */);
             channel.isStarted(isVideoOn);
         });
     }


### PR DESCRIPTION
While setting the element for the container, 'source' property is defined in 'stream' property and not in the 'channel'.