### PR TITLE
Deprecate App SDK

### DIFF
--- a/Skype/AppSDK/SkypeAppSDK.md
+++ b/Skype/AppSDK/SkypeAppSDK.md
@@ -1,15 +1,16 @@
 
+
 # Skype for Business App SDK
 
  **Last modified:** April 23, 2016
 
  _**Applies to:** Skype for Business 2015 CU4_, _Skype for Business Online_
 
+>**Note**: The SDK is now deprecated. No new features or bug fixes will be provided.
+
 The Skype for Business App SDK enables developers to seamlessly integrate messaging, audio, and video experiences into mobile and tablet applications.
 
 The initial focus of this SDK is to power “remote advisor” solutions that enable consumer iOS and Android apps to embed communications from external guests to users within a Skype for Business organization.  To achieve this, the SDK uses the “guest meeting join” capability that is available both for Skype for Business Online and for Skype for Business Server.  
-
-> **Note**: Over time, the SDK's capabilities will expand to cover other scenarios. 
 
 The Skype App SDK documentation consists of the following sections:
 

--- a/Skype/AppSDK/readme.md
+++ b/Skype/AppSDK/readme.md
@@ -1,5 +1,7 @@
 # README
 
+> **Note**: The SDK is now deprecated. No new features or bug fixes will be provided.
+
 This documentation is hosted at http://aka.ms/skypeappsdk.  Please read it there.
 
 If you're interested in contributing to this documentation, then please read on. 


### PR DESCRIPTION
Hi John,

We’re planning on not supporting the SfB App SDK anymore, for multiple reasons:
1.	This SDK is only for SfB Online and we’re planning on moving all SfBO customers to Teams over the next year or two
2.	The SDK is not being used much – we see only 1 app using it, which has 10-50 downloads
3.	Due to #1, we are moving resources away from SfB and cannot work on issues / new feature asks for this SDK

Due to these reasons, could you update the MSDN page for the SDK to state that, “The SDK is now deprecated. No new features or bug fixes will be provided.”
