### PR TITLE
remove dead link (to self?)

### DIFF
--- a/Skype/SkypeDeveloperPlatform.md
+++ b/Skype/SkypeDeveloperPlatform.md
@@ -28,6 +28,5 @@ The table lists the supported SDKs and APIs for Skype for Business Server and Sk
 ## Related sites 
 
 - [Skype](http://www.skype.com/en/)
-- [Skype Developer Platform](http://dev.office.com/skype)
 - [Introducing Skype for Business](http://blogs.skype.com/2014/11/11/introducing-skype-for-business/)
 - [Skype for Business Server 2015](https://technet.microsoft.com/en-us/library/gg398616.aspx)


### PR DESCRIPTION
`dev.office.com` isn't a subdomain that exists, and it seems that the page trying to be referenced is the current page