### PR TITLE
Typo "** Applies to: **"→"**Applies to:**"

### DIFF
--- a/Skype/UCWA/AccessLevel_ref.md
+++ b/Skype/UCWA/AccessLevel_ref.md
@@ -2,7 +2,7 @@
 # AccessLevel
 
 
-_** Applies to: **Skype for Business 2015_
+_**Applies to:** Skype for Business 2015_
 
 Represents the access levels used to control access to an online meeting.
             


### PR DESCRIPTION
Simple removal of blank space to make the MarkDown formatting characters work by adhering to the nearby text, without the unwanted space.

https://docs.microsoft.com/en-us/skype-sdk/ucwa/accesslevel_ref