### PR TITLE
Typo "** Applies to: **"→"**Applies to:**"

### DIFF
--- a/Skype/UCWA/ActivePeriod_ref.md
+++ b/Skype/UCWA/ActivePeriod_ref.md
@@ -2,7 +2,7 @@
 # ActivePeriod
 
 
-_** Applies to: **Skype for Business 2015_
+_**Applies to:** Skype for Business 2015_
 
 Represents when call forwarding settings are active.
             


### PR DESCRIPTION
Simple removal of blank space to make the MarkDown formatting characters work by adhering to the nearby text, without the unwanted space.

https://docs.microsoft.com/en-us/skype-sdk/ucwa/activeperiod_ref