### PR TITLE
Typo "** Applies to: **"→"**Applies to:**"

### DIFF
--- a/Skype/UCWA/AudienceMessaging_ref.md
+++ b/Skype/UCWA/AudienceMessaging_ref.md
@@ -2,7 +2,7 @@
 # AudienceMessaging
 
 
-_** Applies to: **Skype for Business 2015_
+_**Applies to:** Skype for Business 2015_
 
 Represents the states of the [messaging modality](messaging_ref.md) for all members of an audience [conversation](conversation_ref.md).
             


### PR DESCRIPTION
Simple removal of blank space to make the MarkDown formatting characters work by adhering to the nearby text, without the unwanted space.

https://docs.microsoft.com/en-us/skype-sdk/ucwa/audiencemessaging_ref